### PR TITLE
changes the DEFAULT_SCRIPT variable to directly use cdnjs instead of …

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -2,7 +2,7 @@
 const React = require('react');
 const loadScript = require('load-script');
 
-const DEFAULT_SCRIPT = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML';
+const DEFAULT_SCRIPT = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML';
 
 const DEFAULT_OPTIONS = {
     tex2jax: {


### PR DESCRIPTION
…rerouting from cdn.mathjax since cdn.mathjax may be depreciated in the future